### PR TITLE
Release 0.3.35 - WebSocket interception, GraphQL scan, param discovery, adaptive throttling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,98 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) 
 
 ## [Unreleased]
 
+## [0.3.35] — 2026-06-11
+
+This release closes four feature gaps against Burp Suite, each reinforcing the
+AI-native angle (every new capability is reachable both from the UI and as an
+MCP tool the agent can drive). 24 new unit tests; full suite green (79 passed).
+
+### Added — WebSocket frame interception in the MITM proxy
+
+Previously the proxy only logged the WebSocket **upgrade request** and then
+forwarded the connection via a one-shot HTTP call — every frame after the
+handshake was silently dropped, so WebSocket traffic was invisible. This was the
+one real functional gap in an otherwise Burp-parity proxy.
+
+`handle_websocket_upgrade` (the old detection-only stub) is replaced by
+`relay_websocket` in `src-tauri/src/proxy/engine.rs`. On a WebSocket upgrade,
+`handle_connect` now hands **both** stream halves to the relay, which:
+
+- opens a real upstream TLS connection and replays the handshake verbatim,
+- forwards the upstream `101 Switching Protocols` response to the client,
+- relays every frame in **both directions byte-for-byte** (a `tokio::select!`
+  loop, mirroring `tcp_tunnel`), and
+- sniffs a copy of each direction with an RFC 6455 frame parser
+  (`parse_ws_frames`), logging opcode + direction + unmasked text/payload into
+  the proxy's WebSocket pool via `add_websocket_message`.
+
+Forwarding is verbatim, so a parse failure can never corrupt the tunnel —
+parsing is best-effort, for visibility only. Frames are masked-unmasked for
+display (client→server frames are masked per spec).
+
+- **UI:** the WebSocket module (`src/modules/websocket/WebSocket.tsx`) gains an
+  **Intercepted** tab that live-polls `proxy_get_websocket_messages` and shows
+  captured MITM frames grouped by direction (C→S / S→C) with opcode and size.
+- **Agent:** the `proxy_get_websocket_messages` MCP tool now surfaces the full
+  MITM WebSocket stream, not just connections the agent opened itself.
+
+Scope note: 0.3.35 captures and observes frames. Frame editing, hold, and
+proxy-side match-and-replace for WebSocket land in a follow-up.
+
+### Added — GraphQL introspection scan (`graphql_scan`)
+
+New MCP tool + handler `src-tauri/src/mcp/handlers/scanner/graphql.rs`. Given a
+GraphQL endpoint it POSTs the canonical introspection query (type references
+nested seven levels deep so `[String!]!`-style wrappers resolve to the base
+scalar), and:
+
+- reports whether **introspection is enabled** — an information-disclosure
+  finding (`graphql_introspection_enabled`, severity low) when it is, or a clean
+  "good posture" note when it's disabled;
+- parses every query/mutation field and its scalar arguments
+  (`String`/`ID`/`Int`/`Float`/`Boolean`; custom scalars and input objects are
+  skipped), and
+- emits a deduplicated list of **injection points** (field + argument + type +
+  suggested seed value) ready to hand to `active_scan` / `intruder` for
+  SQLi/XSS/SSTI payload testing.
+
+This activates an attack surface that was previously only half-wired (the
+introspection constants in `crawler/well_known.rs` were dead code).
+
+### Added — Hidden-parameter discovery (`discover_parameters`)
+
+The Discovery module's "Hidden Parameters" tab was a sequential, client-side
+size/status diff loop. It now runs through a real backend (`handle_discover_
+parameters` in `src-tauri/src/mcp/handlers/recon.rs`), exposed both as the
+`discover_parameters` MCP tool and to the UI via `mcp_execute_tool`:
+
+- concurrent probing (bounded semaphore) of a small/medium parameter wordlist,
+- detection by **canary reflection**, status-code change, or response-size delta
+  (>50 B) versus a baseline — the decision logic lives in a unit-tested
+  `param_evidence` helper, and
+- support for GET/HEAD (query string) and POST/PUT/PATCH (JSON body).
+
+`src/modules/discovery/Discovery.tsx` is rewired to the new tool, gaining
+reflection detection the old client-side loop never had.
+
+### Added — Adaptive throttling / rate-limit handling in Intruder
+
+New `src-tauri/src/backoff.rs` state machine. When a target answers `429` or
+`503`, the Intruder dispatch loop now backs off automatically instead of holding
+a fixed `throttle_ms`:
+
+- honors `Retry-After` (numeric seconds **or** HTTP-date — the weekday is
+  stripped before parsing so a slightly-malformed header is still honored),
+- exponential backoff capped at `max_backoff_ms` (default 30 s), and
+- decays back toward the base delay after a run of clean responses.
+
+The state machine is additive (tracks the current delay directly) rather than
+multiplier-based, so it stays correct even at the default `throttle_ms = 0`
+(where a multiplier model would divide by zero). New `IntruderConfig` fields
+`adaptive_throttle` (default on) and `max_backoff_ms` are serde-defaulted, so
+attack configs written before 0.3.35 still deserialize. Surfaced through the
+`intruder_start` MCP handler.
+
 ## [0.3.34] — 2026-05-30
 
 ### Fixed — Export as ZIP (and all binary exports) produced an empty file

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {  "name": "wondersuite",
   "private": true,
-  "version": "0.3.34",
+  "version": "0.3.35",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -6630,7 +6630,7 @@ dependencies = [
 
 [[package]]
 name = "wondersuite"
-version = "0.3.34"
+version = "0.3.35"
 dependencies = [
  "axum",
  "base64 0.22.1",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wondersuite"
-version = "0.3.34"
+version = "0.3.35"
 description = "AI-Native Web Security Testing Platform"
 authors = ["WonderSuite Team"]
 edition = "2021"

--- a/src-tauri/src/backoff.rs
+++ b/src-tauri/src/backoff.rs
@@ -1,0 +1,206 @@
+//! Shared adaptive-throttling / rate-limit handling (v0.3.35).
+//!
+//! Used by the Intruder dispatch loop (and available to the scanner) to slow
+//! down automatically when a target starts answering `429 Too Many Requests`
+//! or `503 Service Unavailable`, then recover once it calms down.
+//!
+//! The state machine is intentionally additive (it tracks the current delay in
+//! milliseconds directly) rather than multiplier-based: the Intruder's default
+//! `throttle_ms` is `0`, and a multiplier model would divide by the base delay.
+//! Tracking `current_ms` keeps the math correct even when the base delay is 0 —
+//! the first rate-limit bootstraps from a small seed and grows from there.
+
+/// Small seed used to bootstrap the backoff when there is no base throttle and
+/// no current delay yet (i.e. the user did not configure a throttle but the
+/// target just rate-limited us).
+const BOOTSTRAP_MS: u64 = 250;
+
+/// Parse a `Retry-After` header value (RFC 7231 §7.1.3).
+///
+/// Two accepted forms:
+///   * delay-seconds — a non-negative integer, e.g. `"120"`
+///   * HTTP-date (IMF-fixdate) — e.g. `"Wed, 21 Oct 2025 07:28:00 GMT"`
+///
+/// Returns the number of seconds to wait, or `None` if the value cannot be
+/// parsed. An HTTP-date in the past yields `Some(0)`.
+pub fn parse_retry_after(header_value: &str) -> Option<u64> {
+    let trimmed = header_value.trim();
+    if trimmed.is_empty() {
+        return None;
+    }
+
+    // Form 1: delay-seconds.
+    if let Ok(secs) = trimmed.parse::<u64>() {
+        return Some(secs);
+    }
+
+    // Form 2: HTTP-date, e.g. "Wed, 21 Oct 2025 07:28:00 GMT". chrono is already
+    // a dependency (no extra crate). We strip the leading weekday before parsing:
+    // chrono otherwise rejects dates whose weekday name is inconsistent, and we'd
+    // rather honor a slightly-malformed Retry-After than ignore it.
+    let date_part = trimmed.split_once(", ").map(|(_, rest)| rest).unwrap_or(trimmed);
+    if let Ok(naive) = chrono::NaiveDateTime::parse_from_str(date_part, "%d %b %Y %H:%M:%S GMT") {
+        let target = chrono::DateTime::<chrono::Utc>::from_naive_utc_and_offset(naive, chrono::Utc);
+        let now = chrono::Utc::now();
+        if target > now {
+            return Some((target - now).num_seconds().max(1) as u64);
+        }
+        return Some(0);
+    }
+
+    None
+}
+
+/// Adaptive backoff state machine.
+///
+/// Call [`on_rate_limit`](BackoffState::on_rate_limit) when a response is
+/// `429`/`503` and [`on_success`](BackoffState::on_success) otherwise; read the
+/// delay to apply with [`current_delay_ms`](BackoffState::current_delay_ms).
+#[derive(Debug, Clone)]
+pub struct BackoffState {
+    /// Floor delay in ms — the current delay never drops below this.
+    base_delay_ms: u64,
+    /// Hard cap in ms — the current delay never rises above this.
+    max_backoff_ms: u64,
+    /// The current inter-dispatch delay in ms.
+    current_ms: u64,
+    /// Consecutive successes since the last rate-limit / decay step.
+    success_count: u32,
+    /// Successes required before decaying one step toward the base delay.
+    decay_threshold: u32,
+}
+
+impl BackoffState {
+    /// Create a new state. `max_backoff_ms` is clamped up to at least
+    /// `base_delay_ms` so the cap can never sit below the floor.
+    pub fn new(base_delay_ms: u64, max_backoff_ms: u64) -> Self {
+        Self {
+            base_delay_ms,
+            max_backoff_ms: max_backoff_ms.max(base_delay_ms),
+            current_ms: base_delay_ms,
+            success_count: 0,
+            decay_threshold: 5,
+        }
+    }
+
+    /// The delay to apply right now, clamped to `[base, max]`.
+    pub fn current_delay_ms(&self) -> u64 {
+        self.current_ms.clamp(self.base_delay_ms, self.max_backoff_ms)
+    }
+
+    /// Record a non-rate-limited response. After `decay_threshold` consecutive
+    /// successes the delay decays ~20 % toward the base.
+    pub fn on_success(&mut self) {
+        self.success_count = self.success_count.saturating_add(1);
+        if self.success_count >= self.decay_threshold && self.current_ms > self.base_delay_ms {
+            let decayed = (self.current_ms as f64 * 0.8) as u64;
+            self.current_ms = decayed.max(self.base_delay_ms);
+            self.success_count = 0;
+        }
+    }
+
+    /// Record a `429`/`503`. Doubles the current delay (bootstrapping from a
+    /// seed when there is none), raises it to at least the server-supplied
+    /// `Retry-After`, and clamps to the configured cap.
+    pub fn on_rate_limit(&mut self, retry_after_secs: Option<u64>) {
+        self.success_count = 0;
+        let doubled = if self.current_ms == 0 {
+            self.base_delay_ms.max(BOOTSTRAP_MS)
+        } else {
+            self.current_ms.saturating_mul(2)
+        };
+        let floor = retry_after_secs.map(|s| s.saturating_mul(1000)).unwrap_or(0);
+        let cap = self.max_backoff_ms.max(self.base_delay_ms);
+        self.current_ms = doubled.max(floor).min(cap);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_retry_after_numeric() {
+        assert_eq!(parse_retry_after("120"), Some(120));
+        assert_eq!(parse_retry_after("  60 "), Some(60));
+        assert_eq!(parse_retry_after("0"), Some(0));
+    }
+
+    #[test]
+    fn parse_retry_after_invalid() {
+        assert_eq!(parse_retry_after("not-a-number"), None);
+        assert_eq!(parse_retry_after(""), None);
+        assert_eq!(parse_retry_after("   "), None);
+    }
+
+    #[test]
+    fn parse_retry_after_http_date_future() {
+        // A date far in the future must yield a large positive wait.
+        let secs = parse_retry_after("Wed, 21 Oct 2099 07:28:00 GMT");
+        assert!(secs.is_some());
+        assert!(secs.unwrap() > 1_000_000);
+    }
+
+    #[test]
+    fn parse_retry_after_http_date_past() {
+        // A date in the past yields 0 (don't wait), not None.
+        assert_eq!(parse_retry_after("Wed, 21 Oct 1999 07:28:00 GMT"), Some(0));
+    }
+
+    #[test]
+    fn initial_delay_is_base() {
+        let s = BackoffState::new(100, 5000);
+        assert_eq!(s.current_delay_ms(), 100);
+    }
+
+    #[test]
+    fn exponential_growth() {
+        let mut s = BackoffState::new(100, 5000);
+        s.on_rate_limit(None);
+        assert_eq!(s.current_delay_ms(), 200);
+        s.on_rate_limit(None);
+        assert_eq!(s.current_delay_ms(), 400);
+        s.on_rate_limit(None);
+        assert_eq!(s.current_delay_ms(), 800);
+    }
+
+    #[test]
+    fn growth_is_capped() {
+        let mut s = BackoffState::new(100, 1000);
+        for _ in 0..10 {
+            s.on_rate_limit(None);
+        }
+        assert_eq!(s.current_delay_ms(), 1000);
+    }
+
+    #[test]
+    fn zero_base_bootstraps_on_rate_limit() {
+        // The real-world default: throttle_ms = 0, max_backoff_ms = 30000.
+        let mut s = BackoffState::new(0, 30000);
+        assert_eq!(s.current_delay_ms(), 0); // no delay under normal conditions
+        s.on_rate_limit(None);
+        assert_eq!(s.current_delay_ms(), BOOTSTRAP_MS); // bootstraps, no div-by-zero
+        s.on_rate_limit(None);
+        assert_eq!(s.current_delay_ms(), BOOTSTRAP_MS * 2);
+    }
+
+    #[test]
+    fn retry_after_is_a_floor() {
+        let mut s = BackoffState::new(100, 10000);
+        s.on_rate_limit(Some(5)); // 5s = 5000ms, well above the 200ms double
+        assert!(s.current_delay_ms() >= 5000);
+    }
+
+    #[test]
+    fn decays_after_successes() {
+        let mut s = BackoffState::new(100, 5000);
+        s.on_rate_limit(None);
+        s.on_rate_limit(None);
+        assert_eq!(s.current_delay_ms(), 400);
+        for _ in 0..5 {
+            s.on_success();
+        }
+        let after = s.current_delay_ms();
+        assert!(after < 400 && after >= 100, "expected decay below 400, got {after}");
+    }
+}

--- a/src-tauri/src/intruder.rs
+++ b/src-tauri/src/intruder.rs
@@ -3,6 +3,8 @@ use std::collections::HashMap;
 use std::sync::Arc;
 use tokio::sync::Mutex;
 
+use crate::backoff::{parse_retry_after, BackoffState};
+
 pub type IntruderState = Arc<Mutex<IntruderManager>>;
 
 // v0.3.10: global accessor so MCP handlers can drive the Intruder engine
@@ -96,6 +98,23 @@ pub struct IntruderConfig {
     pub threads: usize,
     pub throttle_ms: u64,
     pub follow_redirects: bool,
+    // v0.3.35: adaptive throttling. When `adaptive_throttle` is on (default) and
+    // the target answers 429/503, the inter-dispatch delay grows exponentially
+    // (honoring Retry-After), capped at `max_backoff_ms`, and decays back toward
+    // `throttle_ms` once the target recovers. Both fields are serde-defaulted so
+    // configs written before 0.3.35 still deserialize.
+    #[serde(default = "default_adaptive_throttle")]
+    pub adaptive_throttle: bool,
+    #[serde(default = "default_max_backoff_ms")]
+    pub max_backoff_ms: u64,
+}
+
+fn default_adaptive_throttle() -> bool {
+    true
+}
+
+fn default_max_backoff_ms() -> u64 {
+    30_000 // 30s ceiling
 }
 
 fn generate_payloads(set: &PayloadSet) -> Vec<String> {
@@ -362,6 +381,8 @@ pub async fn start_attack_from_state(state: IntruderState, config: IntruderConfi
     let grep_rules = config.grep_rules.clone();
     let throttle = config.throttle_ms;
     let follow_redirects = config.follow_redirects;
+    let adaptive = config.adaptive_throttle;
+    let max_backoff = config.max_backoff_ms;
     // v0.3.10: `config.threads` is finally honored. Defaults to 10 if the
     // caller passes 0 (the JSON-default route). Previously the runner was a
     // strict sequential `for` loop — documented multi-thread feature was a
@@ -387,6 +408,12 @@ pub async fn start_attack_from_state(state: IntruderState, config: IntruderConfi
         let start = std::time::Instant::now();
         let sem = Arc::new(Semaphore::new(concurrency));
         let mut handles: Vec<tokio::task::JoinHandle<()>> = Vec::new();
+
+        // v0.3.35: adaptive inter-dispatch backoff. `inspected` tracks how many
+        // results we have already folded into the backoff state so we only react
+        // to responses that landed since the previous dispatch.
+        let mut backoff = BackoffState::new(throttle, max_backoff);
+        let mut inspected: usize = 0;
 
         for (i, payloads) in payload_matrix.iter().enumerate() {
             // Pause / stop check — once per dispatch. Cheap, just reads the
@@ -535,8 +562,53 @@ pub async fn start_attack_from_state(state: IntruderState, config: IntruderConfi
 
             // Inter-dispatch throttle (NOT per completion). Cheap delay so we
             // can drip-feed concurrency on rate-limited targets.
-            if throttle > 0 {
-                tokio::time::sleep(std::time::Duration::from_millis(throttle)).await;
+            //
+            // v0.3.35: when adaptive throttling is on, fold any results that
+            // landed since the last dispatch into the backoff state — a 429/503
+            // grows the delay (honoring Retry-After) and clean responses decay
+            // it back toward `throttle`. With adaptive off we keep the original
+            // fixed `throttle` behaviour.
+            let delay_ms = if adaptive {
+                let mut rate_limited = false;
+                let mut retry_after: Option<u64> = None;
+                let mut saw_new = false;
+                {
+                    let mgr = state_clone.lock().await;
+                    if let Some(attack) = mgr.attacks.get(&aid) {
+                        let len = attack.results.len();
+                        if len > inspected {
+                            saw_new = true;
+                            for r in &attack.results[inspected..len] {
+                                if r.status == 429 || r.status == 503 {
+                                    rate_limited = true;
+                                    if retry_after.is_none() {
+                                        retry_after = r.response_headers.lines().find_map(|line| {
+                                            let (name, val) = line.split_once(':')?;
+                                            if name.trim().eq_ignore_ascii_case("retry-after") {
+                                                parse_retry_after(val.trim())
+                                            } else {
+                                                None
+                                            }
+                                        });
+                                    }
+                                }
+                            }
+                            inspected = len;
+                        }
+                    }
+                }
+                if rate_limited {
+                    backoff.on_rate_limit(retry_after);
+                } else if saw_new {
+                    backoff.on_success();
+                }
+                backoff.current_delay_ms()
+            } else {
+                throttle
+            };
+
+            if delay_ms > 0 {
+                tokio::time::sleep(std::time::Duration::from_millis(delay_ms)).await;
             }
         }
 
@@ -651,4 +723,45 @@ pub async fn intruder_delete(
 fn chrono_now() -> String {
     let now = std::time::SystemTime::now().duration_since(std::time::UNIX_EPOCH).unwrap_or_default();
     format!("{}Z", now.as_secs())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// v0.3.35: configs serialized before adaptive throttling existed must
+    /// still deserialize, defaulting `adaptive_throttle` on and the cap to 30s.
+    #[test]
+    fn config_without_adaptive_fields_uses_defaults() {
+        let json = serde_json::json!({
+            "attack_type": "sniper",
+            "request_template": "GET / HTTP/1.1\r\nHost: example.com\r\n\r\n",
+            "payload_sets": [],
+            "grep_rules": [],
+            "threads": 1,
+            "throttle_ms": 100,
+            "follow_redirects": false
+        });
+        let cfg: IntruderConfig = serde_json::from_value(json).expect("legacy config must deserialize");
+        assert!(cfg.adaptive_throttle);
+        assert_eq!(cfg.max_backoff_ms, 30_000);
+    }
+
+    #[test]
+    fn config_with_adaptive_fields_round_trips() {
+        let json = serde_json::json!({
+            "attack_type": "sniper",
+            "request_template": "GET / HTTP/1.1\r\nHost: example.com\r\n\r\n",
+            "payload_sets": [],
+            "grep_rules": [],
+            "threads": 4,
+            "throttle_ms": 0,
+            "follow_redirects": true,
+            "adaptive_throttle": false,
+            "max_backoff_ms": 5000
+        });
+        let cfg: IntruderConfig = serde_json::from_value(json).expect("config must deserialize");
+        assert!(!cfg.adaptive_throttle);
+        assert_eq!(cfg.max_backoff_ms, 5000);
+    }
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1,3 +1,4 @@
+mod backoff;
 mod browser;
 mod browser_migration;
 mod chromium;

--- a/src-tauri/src/mcp/handlers/intruder.rs
+++ b/src-tauri/src/mcp/handlers/intruder.rs
@@ -45,6 +45,10 @@ pub async fn handle_intruder_start(params: &serde_json::Value) -> HandlerResult 
         cfg_val["max_concurrent"].as_u64().or_else(|| cfg_val["threads"].as_u64()).unwrap_or(10) as usize;
     let throttle_ms = cfg_val["delay_ms"].as_u64().or_else(|| cfg_val["throttle_ms"].as_u64()).unwrap_or(0);
     let follow_redirects = cfg_val["follow_redirects"].as_bool().unwrap_or(false);
+    // v0.3.35: adaptive throttling. Defaults mirror IntruderConfig's serde
+    // defaults so an agent that omits them gets automatic 429/503 backoff.
+    let adaptive_throttle = cfg_val["adaptive_throttle"].as_bool().unwrap_or(true);
+    let max_backoff_ms = cfg_val["max_backoff_ms"].as_u64().unwrap_or(30_000);
 
     // Translate `positions` (intruder_config) OR `payload_sets` (raw) into
     // PayloadSets. send_to_intruder positions carry their payload-category
@@ -83,6 +87,8 @@ pub async fn handle_intruder_start(params: &serde_json::Value) -> HandlerResult 
         "threads": threads,
         "throttle_ms": throttle_ms,
         "follow_redirects": follow_redirects,
+        "adaptive_throttle": adaptive_throttle,
+        "max_backoff_ms": max_backoff_ms,
     });
     let cfg: crate::intruder::IntruderConfig =
         serde_json::from_value(config_json).map_err(|e| format!("Failed to build IntruderConfig: {}", e))?;

--- a/src-tauri/src/mcp/handlers/mod.rs
+++ b/src-tauri/src/mcp/handlers/mod.rs
@@ -83,6 +83,7 @@ pub async fn dispatch(name: &str, params: &serde_json::Value) -> HandlerResult {
         "crawl_target" => recon::handle_crawl_target(params).await,
         "discover_subdomains" => recon::handle_discover_subdomains(params).await,
         "discover_content" => recon::handle_discover_content(params).await,
+        "discover_parameters" => recon::handle_discover_parameters(params).await,
         "find_secrets" => recon::handle_find_secrets(params).await,
         "dns_resolve" => recon::handle_dns_resolve(params).await,
         // v0.3.10: client-side library + version detection (detection only;
@@ -137,6 +138,7 @@ pub async fn dispatch(name: &str, params: &serde_json::Value) -> HandlerResult {
         "passive_scan" => scanner::passive::handle_passive_scan(params).await,
         "fuzz_request" => scanner::fuzzer::handle_fuzz_request(params).await,
         "active_scan" => scanner::active::handle_active_scan(params).await,
+        "graphql_scan" => scanner::graphql::handle_graphql_scan(params).await,
         "generate_report" => scanner::reporting::handle_generate_report(params).await,
 
         _ => Err(format!("Unknown tool: {}", name)),

--- a/src-tauri/src/mcp/handlers/recon.rs
+++ b/src-tauri/src/mcp/handlers/recon.rs
@@ -929,6 +929,216 @@ pub async fn handle_find_secrets(params: &serde_json::Value) -> HandlerResult {
     )
 }
 
+/// v0.3.35: parameter mining (à la Param Miner). The injected canary value used
+/// to detect reflection. Deliberately unusual so it almost never collides with
+/// content that already exists in the baseline response.
+const PARAM_CANARY: &str = "wsx9k3probe";
+
+/// Decide whether a probe response reveals a hidden parameter relative to the
+/// baseline. Returns `Some(evidence)` when interesting, else `None`. Extracted
+/// from the handler so the detection logic is unit-testable.
+fn param_evidence(
+    baseline_status: u16,
+    baseline_size: usize,
+    probe_status: u16,
+    probe_size: usize,
+    probe_body: &str,
+) -> Option<String> {
+    const SIZE_DELTA: i64 = 50;
+    if probe_body.contains(PARAM_CANARY) {
+        return Some("value reflected in response".to_string());
+    }
+    if probe_status != baseline_status {
+        return Some(format!("status changed {} -> {}", baseline_status, probe_status));
+    }
+    let delta = (probe_size as i64 - baseline_size as i64).abs();
+    if delta > SIZE_DELTA {
+        return Some(format!("response size {}B -> {}B (diff {}B)", baseline_size, probe_size, delta));
+    }
+    None
+}
+
+fn parameter_wordlist(size: &str) -> Vec<&'static str> {
+    let small = [
+        "id", "page", "q", "search", "debug", "test", "admin", "token", "key", "api_key", "secret",
+        "callback", "redirect", "url", "file", "user", "lang", "format", "action", "next",
+    ];
+    let extra = [
+        "query",
+        "apikey",
+        "password",
+        "pass",
+        "username",
+        "email",
+        "redirect_uri",
+        "return",
+        "return_url",
+        "uri",
+        "path",
+        "filename",
+        "include",
+        "template",
+        "language",
+        "type",
+        "output",
+        "v",
+        "version",
+        "limit",
+        "offset",
+        "sort",
+        "order",
+        "filter",
+        "category",
+        "tag",
+        "status",
+        "role",
+        "access",
+        "auth",
+        "view",
+        "mode",
+        "config",
+        "setting",
+        "option",
+        "cmd",
+        "command",
+        "exec",
+        "eval",
+        "load",
+        "file_path",
+        "download",
+        "upload",
+        "preview",
+        "size",
+        "width",
+        "height",
+        "start",
+        "end",
+        "from",
+        "to",
+        "skip",
+        "take",
+        "count",
+        "per_page",
+        "page_size",
+    ];
+    match size {
+        "small" => small.to_vec(),
+        _ => small.iter().chain(extra.iter()).copied().collect(),
+    }
+}
+
+/// Discover hidden request parameters by probing candidate names and diffing the
+/// response against a baseline (reflection / status / size). Exposed both as the
+/// `discover_parameters` MCP tool and the `discover_parameters` Tauri command.
+pub async fn handle_discover_parameters(params: &serde_json::Value) -> HandlerResult {
+    let target = params["target"].as_str().ok_or("Missing target")?.to_string();
+    let method = params["method"].as_str().unwrap_or("GET").to_uppercase();
+    let wordlist = params["wordlist"].as_str().unwrap_or("medium").to_string();
+    let max_concurrent = params["max_concurrent"].as_u64().unwrap_or(10).clamp(1, 50) as usize;
+    let timeout_ms = params["timeout_ms"].as_u64().unwrap_or(5000);
+
+    let client = reqwest::Client::builder()
+        .danger_accept_invalid_certs(true)
+        .timeout(std::time::Duration::from_millis(timeout_ms))
+        .build()
+        .map_err(|e| e.to_string())?;
+
+    let names = parameter_wordlist(&wordlist);
+
+    // Baseline: the unmodified request.
+    let baseline_resp = match method.as_str() {
+        "POST" => client.post(&target).send().await,
+        "PUT" => client.put(&target).send().await,
+        "PATCH" => client.patch(&target).send().await,
+        "HEAD" => client.head(&target).send().await,
+        _ => client.get(&target).send().await,
+    }
+    .map_err(|e| format!("baseline request failed: {}", e))?;
+    let baseline_status = baseline_resp.status().as_u16();
+    let baseline_body = baseline_resp.text().await.unwrap_or_default();
+    let baseline_size = baseline_body.len();
+
+    let sem = Arc::new(tokio::sync::Semaphore::new(max_concurrent));
+    let client = Arc::new(client);
+    let mut handles = Vec::new();
+
+    for name in names.iter().copied() {
+        let sem = sem.clone();
+        let client = client.clone();
+        let target = target.clone();
+        let method = method.clone();
+        let name = name.to_string();
+        handles.push(tokio::spawn(async move {
+            let _permit = sem.acquire().await.ok()?;
+            let probe_url = if matches!(method.as_str(), "GET" | "HEAD") {
+                let sep = if target.contains('?') { '&' } else { '?' };
+                format!("{}{}{}={}", target, sep, name, PARAM_CANARY)
+            } else {
+                target.clone()
+            };
+            let resp = match method.as_str() {
+                "POST" => {
+                    client
+                        .post(&probe_url)
+                        .header("content-type", "application/json")
+                        .body(format!("{{\"{}\":\"{}\"}}", name, PARAM_CANARY))
+                        .send()
+                        .await
+                }
+                "PUT" => {
+                    client
+                        .put(&probe_url)
+                        .header("content-type", "application/json")
+                        .body(format!("{{\"{}\":\"{}\"}}", name, PARAM_CANARY))
+                        .send()
+                        .await
+                }
+                "PATCH" => {
+                    client
+                        .patch(&probe_url)
+                        .header("content-type", "application/json")
+                        .body(format!("{{\"{}\":\"{}\"}}", name, PARAM_CANARY))
+                        .send()
+                        .await
+                }
+                "HEAD" => client.head(&probe_url).send().await,
+                _ => client.get(&probe_url).send().await,
+            };
+            let resp = resp.ok()?;
+            let probe_status = resp.status().as_u16();
+            let probe_body = resp.text().await.unwrap_or_default();
+            let probe_size = probe_body.len();
+            let evidence =
+                param_evidence(baseline_status, baseline_size, probe_status, probe_size, &probe_body)?;
+            Some(serde_json::json!({
+                "param": name,
+                "evidence": evidence,
+                "status_code": probe_status,
+                "response_size": probe_size,
+            }))
+        }));
+    }
+
+    let mut results = Vec::new();
+    for h in handles {
+        if let Ok(Some(v)) = h.await {
+            results.push(v);
+        }
+    }
+    results.sort_by(|a, b| a["param"].as_str().unwrap_or("").cmp(b["param"].as_str().unwrap_or("")));
+
+    Ok(serde_json::json!({
+        "target": target,
+        "method": method,
+        "wordlist": wordlist,
+        "baseline_status": baseline_status,
+        "baseline_size": baseline_size,
+        "parameters_tested": names.len(),
+        "parameters_found": results.len(),
+        "results": results,
+    }))
+}
+
 pub async fn handle_dns_resolve(params: &serde_json::Value) -> HandlerResult {
     let domain = params["domain"].as_str().ok_or("Missing domain")?;
     let mut results = Vec::new();
@@ -975,4 +1185,42 @@ pub async fn handle_dns_resolve(params: &serde_json::Value) -> HandlerResult {
     Ok(
         serde_json::json!({"domain": domain, "records": results, "unique_ips": ips, "cdn_indicators": cdn_indicators, "origin_subdomain_hints": origin_hints, "tip": "Use raw_tcp_send with Host header override to test direct-to-origin bypassing CDN edge"}),
     )
+}
+
+#[cfg(test)]
+mod param_discovery_tests {
+    use super::*;
+
+    #[test]
+    fn reflection_is_detected() {
+        let body = format!("<html>hello {} world</html>", PARAM_CANARY);
+        let ev = param_evidence(200, 100, 200, 100 + body.len(), &body);
+        assert!(ev.unwrap().contains("reflected"));
+    }
+
+    #[test]
+    fn status_change_is_detected() {
+        let ev = param_evidence(404, 200, 200, 200, "no canary here");
+        assert!(ev.unwrap().contains("status changed"));
+    }
+
+    #[test]
+    fn large_size_change_is_detected() {
+        let ev = param_evidence(200, 100, 200, 200, "no canary here");
+        assert!(ev.unwrap().contains("response size"));
+    }
+
+    #[test]
+    fn no_change_is_ignored() {
+        // Same status, near-identical size, no reflection -> not interesting.
+        assert!(param_evidence(200, 100, 200, 120, "ordinary response").is_none());
+    }
+
+    #[test]
+    fn wordlist_sizes() {
+        assert_eq!(parameter_wordlist("small").len(), 20);
+        assert!(parameter_wordlist("medium").len() > parameter_wordlist("small").len());
+        // unknown sizes fall back to the medium list
+        assert_eq!(parameter_wordlist("large").len(), parameter_wordlist("medium").len());
+    }
 }

--- a/src-tauri/src/mcp/handlers/scanner/graphql.rs
+++ b/src-tauri/src/mcp/handlers/scanner/graphql.rs
@@ -1,0 +1,397 @@
+//! GraphQL introspection → injection-surface enumeration (v0.3.35).
+//!
+//! Given a GraphQL endpoint, this:
+//!   1. POSTs the standard introspection query,
+//!   2. reports whether introspection is enabled (an information-disclosure
+//!      finding when it is),
+//!   3. parses the schema into queries/mutations and their scalar arguments,
+//!   4. emits a structured list of injection points (field + argument + type)
+//!      that the agent can hand to `intruder` / `active_scan` for payload tests.
+//!
+//! Scope note (0.3.35): this maps the attack surface. It deliberately does NOT
+//! fire payloads into GraphQL arguments itself — building valid operation
+//! documents for arbitrary fields is follow-up work. The returned injection
+//! points are the agent's launch pad.
+
+use crate::mcp::types::HandlerResult;
+use serde_json::{json, Value};
+use std::collections::HashSet;
+
+/// Scalar types worth fuzzing for injection.
+const SCALAR_TYPES: &[&str] = &["String", "ID", "Int", "Float", "Boolean"];
+
+/// The canonical GraphQL introspection query. `ofType` is nested seven levels
+/// deep so wrappers like `[String!]!` resolve all the way down to the scalar.
+const INTROSPECTION_QUERY: &str = "{ __schema { queryType { name } mutationType { name } types { name kind fields(includeDeprecated: false) { name args { name type { kind name ofType { kind name ofType { kind name ofType { kind name ofType { kind name ofType { kind name ofType { kind name } } } } } } } } } } } }";
+
+#[derive(Debug, Clone)]
+pub struct GraphQLArgument {
+    pub arg_name: String,
+    pub arg_type: String,
+    pub is_required: bool,
+    pub is_list: bool,
+}
+
+#[derive(Debug, Clone)]
+pub struct GraphQLField {
+    pub name: String,
+    pub arguments: Vec<GraphQLArgument>,
+}
+
+#[derive(Debug, Clone)]
+pub struct GraphQLSchema {
+    pub queries: Vec<GraphQLField>,
+    pub mutations: Vec<GraphQLField>,
+}
+
+/// One injectable GraphQL argument. Serialized into the tool response.
+#[derive(Debug, Clone)]
+pub struct GqlInjectionPoint {
+    pub operation: String, // "query" | "mutation"
+    pub field: String,
+    pub arg_name: String,
+    pub arg_type: String,
+    pub required: bool,
+    pub suggested_value: String,
+}
+
+impl GqlInjectionPoint {
+    pub fn name(&self) -> String {
+        format!("{}.{}", self.field, self.arg_name)
+    }
+    fn to_json(&self) -> Value {
+        json!({
+            "name": self.name(),
+            "operation": self.operation,
+            "field": self.field,
+            "arg": self.arg_name,
+            "type": self.arg_type,
+            "required": self.required,
+            "suggested_value": self.suggested_value,
+        })
+    }
+}
+
+fn is_scalar_type(t: &str) -> bool {
+    SCALAR_TYPES.contains(&t)
+}
+
+fn suggested_value(arg_type: &str) -> String {
+    match arg_type {
+        "Int" | "Float" => "1".to_string(),
+        "Boolean" => "true".to_string(),
+        _ => "test".to_string(),
+    }
+}
+
+/// Walk a (possibly nested) introspection type ref and return
+/// `(base_scalar_name, is_required, is_list)`.
+fn extract_type_info(type_obj: &Value) -> (String, bool, bool) {
+    let mut current = type_obj;
+    let mut is_required = false;
+    let mut is_list = false;
+
+    loop {
+        match current["kind"].as_str() {
+            Some("NON_NULL") | Some("NonNull") => {
+                is_required = true;
+                if current["ofType"].is_object() {
+                    current = &current["ofType"];
+                } else {
+                    break;
+                }
+            }
+            Some("LIST") | Some("List") => {
+                is_list = true;
+                if current["ofType"].is_object() {
+                    current = &current["ofType"];
+                } else {
+                    break;
+                }
+            }
+            _ => break,
+        }
+    }
+
+    let base = current["name"].as_str().unwrap_or("").to_string();
+    (base, is_required, is_list)
+}
+
+fn extract_argument_info(arg: &Value) -> Option<GraphQLArgument> {
+    let arg_name = arg["name"].as_str()?.to_string();
+    let (base_type, is_required, is_list) = extract_type_info(&arg["type"]);
+    if !is_scalar_type(&base_type) {
+        return None; // only scalar args are fuzzable
+    }
+    Some(GraphQLArgument { arg_name, arg_type: base_type, is_required, is_list })
+}
+
+fn extract_field_info(field: &Value) -> Option<GraphQLField> {
+    let name = field["name"].as_str()?.to_string();
+    let mut arguments = Vec::new();
+    if let Some(args) = field["args"].as_array() {
+        for arg in args {
+            if let Some(info) = extract_argument_info(arg) {
+                arguments.push(info);
+            }
+        }
+    }
+    Some(GraphQLField { name, arguments })
+}
+
+/// Parse an introspection response (`{ data: { __schema: {...} } }`) into a
+/// [`GraphQLSchema`]. Returns `Err` when no `__schema` is present.
+pub fn parse_graphql_schema(_endpoint: &str, data: &Value) -> Result<GraphQLSchema, String> {
+    let schema = &data["data"]["__schema"];
+    if schema.is_null() {
+        return Err("introspection disabled or no __schema in response".into());
+    }
+
+    let query_type = schema["queryType"]["name"].as_str().unwrap_or("Query").to_string();
+    let mutation_type = schema["mutationType"]["name"].as_str().unwrap_or("Mutation").to_string();
+
+    let empty = Vec::new();
+    let types = schema["types"].as_array().unwrap_or(&empty);
+
+    let mut queries = Vec::new();
+    let mut mutations = Vec::new();
+
+    for type_def in types {
+        let name = type_def["name"].as_str().unwrap_or("");
+        if name.starts_with("__") {
+            continue; // skip introspection meta-types
+        }
+        let target = if name == query_type {
+            Some(&mut queries)
+        } else if name == mutation_type {
+            Some(&mut mutations)
+        } else {
+            None
+        };
+        if let Some(bucket) = target {
+            if let Some(fields) = type_def["fields"].as_array() {
+                for field in fields {
+                    if let Some(f) = extract_field_info(field) {
+                        // Only keep fields that actually expose scalar args.
+                        if !f.arguments.is_empty() {
+                            bucket.push(f);
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    Ok(GraphQLSchema { queries, mutations })
+}
+
+/// Flatten a schema into a deduplicated list of injectable arguments.
+pub fn schema_to_injection_points(schema: &GraphQLSchema) -> Vec<GqlInjectionPoint> {
+    let mut points = Vec::new();
+    let mut seen = HashSet::new();
+
+    for (operation, fields) in [("query", &schema.queries), ("mutation", &schema.mutations)] {
+        for field in fields {
+            for arg in &field.arguments {
+                let key = format!("{}|{}|{}", operation, field.name, arg.arg_name);
+                if seen.insert(key) {
+                    points.push(GqlInjectionPoint {
+                        operation: operation.to_string(),
+                        field: field.name.clone(),
+                        arg_name: arg.arg_name.clone(),
+                        arg_type: arg.arg_type.clone(),
+                        required: arg.is_required,
+                        suggested_value: suggested_value(&arg.arg_type),
+                    });
+                }
+            }
+        }
+    }
+    points
+}
+
+async fn introspect_graphql(
+    endpoint: &str,
+    headers: Option<&serde_json::Map<String, Value>>,
+) -> Result<Value, String> {
+    let client = reqwest::Client::builder()
+        .danger_accept_invalid_certs(true)
+        .timeout(std::time::Duration::from_secs(15))
+        .build()
+        .map_err(|e| e.to_string())?;
+
+    let mut req = client
+        .post(endpoint)
+        .header("content-type", "application/json")
+        .body(json!({ "query": INTROSPECTION_QUERY }).to_string());
+
+    if let Some(obj) = headers {
+        for (k, v) in obj {
+            if let Some(s) = v.as_str() {
+                req = req.header(k.as_str(), s);
+            }
+        }
+    }
+
+    let resp = req.send().await.map_err(|e| format!("introspection request failed: {}", e))?;
+    let body = resp.text().await.map_err(|e| e.to_string())?;
+    serde_json::from_str::<Value>(&body).map_err(|e| format!("non-JSON introspection response: {}", e))
+}
+
+/// MCP tool `graphql_scan`: introspect a GraphQL endpoint and enumerate its
+/// injectable argument surface.
+pub async fn handle_graphql_scan(params: &serde_json::Value) -> HandlerResult {
+    let target = params["target"].as_str().ok_or("Missing target")?;
+    let headers = params["headers"].as_object();
+
+    let data = match introspect_graphql(target, headers).await {
+        Ok(d) => d,
+        Err(e) => {
+            return Ok(json!({
+                "target": target,
+                "introspection_enabled": false,
+                "error": e,
+                "injection_points": [],
+            }));
+        }
+    };
+
+    let schema = match parse_graphql_schema(target, &data) {
+        Ok(s) => s,
+        Err(_) => {
+            // A well-formed JSON response without __schema = introspection is
+            // disabled. That's good security posture, not a finding.
+            return Ok(json!({
+                "target": target,
+                "introspection_enabled": false,
+                "note": "Introspection appears disabled (no __schema returned). Good posture; the argument surface can't be auto-enumerated.",
+                "injection_points": [],
+            }));
+        }
+    };
+
+    let points = schema_to_injection_points(&schema);
+
+    let finding = json!({
+        "finding_type": "graphql_introspection_enabled",
+        "name": "GraphQL introspection enabled",
+        "severity": "low",
+        "confidence": "certain",
+        "url": target,
+        "evidence": format!(
+            "Introspection returned {} query field(s) and {} mutation field(s).",
+            schema.queries.len(), schema.mutations.len()
+        ),
+        "remediation": "Disable introspection in production GraphQL deployments to avoid exposing the full schema.",
+    });
+
+    let surface = |fields: &[GraphQLField]| -> Vec<Value> {
+        fields
+            .iter()
+            .map(|f| {
+                json!({
+                    "field": f.name,
+                    "args": f.arguments.iter().map(|a| json!({
+                        "name": a.arg_name,
+                        "type": a.arg_type,
+                        "required": a.is_required,
+                        "list": a.is_list,
+                    })).collect::<Vec<_>>(),
+                })
+            })
+            .collect()
+    };
+
+    Ok(json!({
+        "target": target,
+        "introspection_enabled": true,
+        "finding": finding,
+        "queries": surface(&schema.queries),
+        "mutations": surface(&schema.mutations),
+        "injection_point_count": points.len(),
+        "injection_points": points.iter().map(|p| p.to_json()).collect::<Vec<_>>(),
+        "next_step": "Feed an injection point's field+arg into intruder, or craft a GraphQL operation with SQLi/XSS/SSTI payloads in that argument.",
+    }))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn sample_introspection() -> Value {
+        json!({
+            "data": { "__schema": {
+                "queryType": { "name": "Query" },
+                "mutationType": { "name": "Mutation" },
+                "types": [
+                    { "name": "Query", "kind": "OBJECT", "fields": [
+                        { "name": "user", "args": [
+                            { "name": "id", "type": { "kind": "NON_NULL", "ofType": { "kind": "SCALAR", "name": "ID" } } },
+                            { "name": "email", "type": { "kind": "SCALAR", "name": "String" } }
+                        ] },
+                        { "name": "search", "args": [
+                            { "name": "q", "type": { "kind": "NON_NULL", "ofType": { "kind": "SCALAR", "name": "String" } } },
+                            { "name": "limit", "type": { "kind": "SCALAR", "name": "Int" } }
+                        ] },
+                        { "name": "noArgs", "args": [] }
+                    ] },
+                    { "name": "Mutation", "kind": "OBJECT", "fields": [
+                        { "name": "createUser", "args": [
+                            { "name": "name", "type": { "kind": "NON_NULL", "ofType": { "kind": "SCALAR", "name": "String" } } }
+                        ] }
+                    ] },
+                    { "name": "__Type", "kind": "OBJECT", "fields": [] }
+                ]
+            } }
+        })
+    }
+
+    #[test]
+    fn parses_query_and_mutation_fields() {
+        let schema = parse_graphql_schema("https://x/graphql", &sample_introspection()).unwrap();
+        // noArgs has no scalar args, so it's dropped; user + search remain.
+        assert_eq!(schema.queries.len(), 2);
+        assert_eq!(schema.queries[0].name, "user");
+        assert_eq!(schema.queries[0].arguments[0].arg_name, "id");
+        assert_eq!(schema.queries[0].arguments[0].arg_type, "ID");
+        assert!(schema.queries[0].arguments[0].is_required);
+        assert!(!schema.queries[0].arguments[1].is_required);
+        assert_eq!(schema.mutations.len(), 1);
+        assert_eq!(schema.mutations[0].name, "createUser");
+    }
+
+    #[test]
+    fn generates_one_point_per_scalar_arg() {
+        let schema = parse_graphql_schema("https://x/graphql", &sample_introspection()).unwrap();
+        let points = schema_to_injection_points(&schema);
+        // user(id,email) + search(q,limit) + createUser(name) = 5
+        assert_eq!(points.len(), 5);
+        assert!(points.iter().any(|p| p.name() == "user.id" && p.operation == "query"));
+        assert!(points.iter().any(|p| p.name() == "createUser.name" && p.operation == "mutation"));
+        let limit = points.iter().find(|p| p.name() == "search.limit").unwrap();
+        assert_eq!(limit.suggested_value, "1");
+    }
+
+    #[test]
+    fn missing_schema_is_an_error() {
+        let data = json!({ "data": { "__schema": null } });
+        assert!(parse_graphql_schema("https://x/graphql", &data).is_err());
+    }
+
+    #[test]
+    fn unwraps_nested_type_wrappers() {
+        // [String!]! -> NON_NULL(LIST(NON_NULL(SCALAR String)))
+        let t = json!({ "kind": "NON_NULL", "ofType": { "kind": "LIST", "ofType": {
+            "kind": "NON_NULL", "ofType": { "kind": "SCALAR", "name": "String" } } } });
+        let (base, req, list) = extract_type_info(&t);
+        assert_eq!(base, "String");
+        assert!(req);
+        assert!(list);
+    }
+
+    #[test]
+    fn custom_scalars_are_skipped() {
+        let arg = json!({ "name": "when", "type": { "kind": "SCALAR", "name": "DateTime" } });
+        assert!(extract_argument_info(&arg).is_none());
+    }
+}

--- a/src-tauri/src/mcp/handlers/scanner/mod.rs
+++ b/src-tauri/src/mcp/handlers/scanner/mod.rs
@@ -1,5 +1,6 @@
 pub mod active;
 pub mod fuzzer;
+pub mod graphql;
 pub mod passive;
 pub mod reporting;
 pub mod source;

--- a/src-tauri/src/mcp/mod.rs
+++ b/src-tauri/src/mcp/mod.rs
@@ -604,6 +604,21 @@ pub fn tool_definitions() -> Vec<ToolDef> {
             }),
         },
         ToolDef {
+            name: "discover_parameters".into(),
+            description: "Discover hidden request parameters (Param-Miner style). Probes candidate names (wordlist: small | medium) against the target and flags any that reflect a canary value, change the status code, or shift the response size (>50B). Works for GET/HEAD (query) and POST/PUT/PATCH (JSON body). Use for parameter pollution, hidden inputs, and undocumented API fields.".into(),
+            input_schema: serde_json::json!({
+                "type": "object",
+                "properties": {
+                    "target": { "type": "string", "description": "Target URL to probe" },
+                    "method": { "type": "string", "enum": ["GET", "POST", "PUT", "PATCH", "HEAD"], "default": "GET" },
+                    "wordlist": { "type": "string", "enum": ["small", "medium"], "default": "medium" },
+                    "max_concurrent": { "type": "integer", "default": 10 },
+                    "timeout_ms": { "type": "integer", "default": 5000 }
+                },
+                "required": ["target"]
+            }),
+        },
+        ToolDef {
             name: "find_secrets".into(),
             description: "Scan text or a URL response for leaked secrets: AWS keys, API keys, JWTs, passwords, database URLs, internal IPs, and more (17 pattern types).".into(),
             input_schema: serde_json::json!({
@@ -1033,6 +1048,18 @@ pub fn tool_definitions() -> Vec<ToolDef> {
                     "headers": { "type": "object", "description": "Header overrides (added on top of any headers from intercept/traffic)." },
                     "body": { "type": "string", "description": "Explicit body override (overrides any body from intercept/traffic)." }
                 }
+            }),
+        },
+        ToolDef {
+            name: "graphql_scan".into(),
+            description: "GraphQL introspection + injection-surface enumeration. POSTs the standard introspection query to a GraphQL endpoint; if introspection is enabled (an information-disclosure finding) it returns every query/mutation field with its scalar arguments and a deduplicated list of injection points (field + arg + type). Feed an injection point into active_scan / intruder to fuzz the argument for SQLi/XSS/SSTI. If introspection is disabled it reports that cleanly (good posture).".into(),
+            input_schema: serde_json::json!({
+                "type": "object",
+                "properties": {
+                    "target": { "type": "string", "description": "GraphQL endpoint URL (e.g. https://api.example.com/graphql)" },
+                    "headers": { "type": "object", "description": "Optional headers to send (e.g. {\"Authorization\": \"Bearer ...\"})." }
+                },
+                "required": ["target"]
             }),
         },
         ToolDef {

--- a/src-tauri/src/proxy/engine.rs
+++ b/src-tauri/src/proxy/engine.rs
@@ -337,6 +337,20 @@ impl ProxyEngine {
                 Err(_) => break,       // Idle timeout
             };
 
+            // v0.3.35: a WebSocket upgrade takes over the whole connection. Hand
+            // BOTH halves to the relay (which holds it open and captures every
+            // frame) instead of the old detection-only stub that forwarded the
+            // handshake and then dropped all frames.
+            if request.is_websocket_upgrade {
+                if let Err(e) = self.relay_websocket(buf_reader, writer, &host, port, request).await {
+                    let msg = e.to_string();
+                    if !is_benign_error(&msg) {
+                        eprintln!("[Proxy] WebSocket relay error for {}: {}", host, msg);
+                    }
+                }
+                return Ok(());
+            }
+
             let should_continue = self.process_tunneled_request(&mut writer, &host, port, request).await;
 
             match should_continue {
@@ -391,10 +405,9 @@ impl ProxyEngine {
             if body.is_empty() { String::new() } else { format!("\r\n{}", body_str) }
         );
 
-        if request.is_websocket_upgrade {
-            self.handle_websocket_upgrade(writer, host, &url, &raw_request, &headers, &body).await?;
-            return Ok(false); // WebSocket takes over
-        }
+        // NOTE: WebSocket upgrades are intercepted earlier, in `handle_connect`,
+        // which hands both stream halves to `relay_websocket`. They never reach
+        // this point.
 
         let mut final_method = method.clone();
         let mut final_url = url.clone();
@@ -870,43 +883,183 @@ impl ProxyEngine {
             .into())
     }
 
-    async fn handle_websocket_upgrade<W: AsyncWriteExt + Unpin>(
+    /// v0.3.35: full WebSocket frame relay for the MITM proxy.
+    ///
+    /// Replaces the old detection-only stub (which forwarded the handshake via a
+    /// one-shot HTTP call and then dropped every frame). After the client's
+    /// upgrade request we open a real upstream TLS connection, replay the
+    /// handshake, forward the `101 Switching Protocols` response to the client,
+    /// then relay every frame in both directions *byte-for-byte* — sniffing a
+    /// copy of each direction to log frames (opcode + direction + unmasked text)
+    /// into the proxy's WebSocket pool. Forwarding is verbatim, so the tunnel is
+    /// never corrupted; parsing is best-effort, for visibility only. Scope for
+    /// 0.3.35 is capture/observe (no frame editing / hold / match-replace).
+    async fn relay_websocket<R, W>(
         &self,
-        writer: &mut W,
+        mut client_reader: R,
+        mut client_writer: W,
         host: &str,
-        url: &str,
-        raw_request: &str,
-        headers: &[(String, String)],
-        body: &[u8],
-    ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+        port: u16,
+        request: WireRequest,
+    ) -> Result<(), Box<dyn std::error::Error + Send + Sync>>
+    where
+        R: AsyncReadExt + Unpin,
+        W: AsyncWriteExt + Unpin,
+    {
+        let connection_id = uuid::Uuid::new_v4().to_string();
+        let url = if port == 443 {
+            format!("wss://{}{}", host, request.path)
+        } else {
+            format!("wss://{}:{}{}", host, port, request.path)
+        };
+
+        // Reconstruct the verbatim upgrade request: request line + headers + the
+        // blank-line terminator. `headers_raw` already ends each header with CRLF
+        // but omits the final blank line.
+        let upgrade_req =
+            format!("{} {} HTTP/1.1\r\n{}\r\n", request.method, request.path, request.headers_raw);
+
         self.state
             .add_websocket_message(WebSocketMessage {
                 id: self.state.next_id(),
-                connection_id: uuid::Uuid::new_v4().to_string(),
+                connection_id: connection_id.clone(),
                 direction: "client_to_server".into(),
                 opcode: "upgrade".into(),
-                data: raw_request.to_string(),
-                length: raw_request.len(),
+                data: upgrade_req.clone(),
+                length: upgrade_req.len(),
                 timestamp: chrono::Utc::now().to_rfc3339(),
                 host: host.to_string(),
-                url: url.to_string(),
+                url: url.clone(),
             })
             .await;
 
-        let result = self.forward_request("GET", url, headers, body).await;
-        if let Ok((status, resp_headers, resp_body)) = result {
-            let mut raw_resp = format!("HTTP/1.1 {}\r\n", status);
-            for (k, v) in &resp_headers {
-                raw_resp.push_str(&format!("{}: {}\r\n", k, v));
+        // Open the upstream TLS connection (this is the CONNECT / HTTPS path).
+        let tcp = TcpStream::connect((host, port)).await?;
+        let connector = native_tls::TlsConnector::builder()
+            .danger_accept_invalid_certs(true)
+            .danger_accept_invalid_hostnames(true)
+            .build()?;
+        let connector = tokio_native_tls::TlsConnector::from(connector);
+        let upstream = connector.connect(host, tcp).await?;
+        let (mut up_read, mut up_write) = tokio::io::split(upstream);
+
+        // Replay the handshake upstream.
+        up_write.write_all(upgrade_req.as_bytes()).await?;
+        up_write.flush().await?;
+
+        // Read the upstream response head (up to CRLF CRLF) and forward it to the
+        // client so the browser sees a real 101 Switching Protocols.
+        let mut resp_head = Vec::new();
+        let mut one = [0u8; 1];
+        loop {
+            let n = up_read.read(&mut one).await?;
+            if n == 0 {
+                break;
             }
-            raw_resp.push_str("\r\n");
-            writer.write_all(raw_resp.as_bytes()).await?;
-            if !resp_body.is_empty() {
-                writer.write_all(&resp_body).await?;
+            resp_head.push(one[0]);
+            if resp_head.ends_with(b"\r\n\r\n") {
+                break;
             }
-            writer.flush().await?;
+            if resp_head.len() > MAX_HEADER_SIZE {
+                return Err("WebSocket upstream response headers too large".into());
+            }
+        }
+        client_writer.write_all(&resp_head).await?;
+        client_writer.flush().await?;
+
+        let resp_head_str = String::from_utf8_lossy(&resp_head).to_string();
+        self.state
+            .add_websocket_message(WebSocketMessage {
+                id: self.state.next_id(),
+                connection_id: connection_id.clone(),
+                direction: "server_to_client".into(),
+                opcode: "upgrade".into(),
+                data: resp_head_str.clone(),
+                length: resp_head_str.len(),
+                timestamp: chrono::Utc::now().to_rfc3339(),
+                host: host.to_string(),
+                url: url.clone(),
+            })
+            .await;
+
+        // Relay both directions until either side closes.
+        let c2s = self.relay_ws_direction(
+            &mut client_reader,
+            &mut up_write,
+            "client_to_server",
+            &connection_id,
+            host,
+            &url,
+        );
+        let s2c = self.relay_ws_direction(
+            &mut up_read,
+            &mut client_writer,
+            "server_to_client",
+            &connection_id,
+            host,
+            &url,
+        );
+        tokio::select! {
+            _ = c2s => {}
+            _ = s2c => {}
         }
 
+        Ok(())
+    }
+
+    /// Relay one direction of a WebSocket stream: forward bytes verbatim, then
+    /// sniff a copy to log each complete frame it can parse.
+    async fn relay_ws_direction<R, W>(
+        &self,
+        from: &mut R,
+        to: &mut W,
+        direction: &str,
+        connection_id: &str,
+        host: &str,
+        url: &str,
+    ) -> std::io::Result<()>
+    where
+        R: AsyncReadExt + Unpin,
+        W: AsyncWriteExt + Unpin,
+    {
+        let mut sniff: Vec<u8> = Vec::new();
+        let mut chunk = [0u8; 8192];
+        loop {
+            let n = from.read(&mut chunk).await?;
+            if n == 0 {
+                break;
+            }
+            // Forward verbatim FIRST — the tunnel must never depend on our
+            // ability to parse a frame.
+            to.write_all(&chunk[..n]).await?;
+            to.flush().await?;
+
+            sniff.extend_from_slice(&chunk[..n]);
+            let (frames, consumed) = parse_ws_frames(&sniff);
+            for f in frames {
+                let (data, length) = render_ws_frame(&f);
+                self.state
+                    .add_websocket_message(WebSocketMessage {
+                        id: self.state.next_id(),
+                        connection_id: connection_id.to_string(),
+                        direction: direction.to_string(),
+                        opcode: ws_opcode_name(f.opcode).to_string(),
+                        data,
+                        length,
+                        timestamp: chrono::Utc::now().to_rfc3339(),
+                        host: host.to_string(),
+                        url: url.to_string(),
+                    })
+                    .await;
+            }
+            if consumed > 0 {
+                sniff.drain(0..consumed);
+            }
+            // Bound memory if we're mid-way through an implausibly large frame.
+            if sniff.len() > 1_048_576 {
+                sniff.clear();
+            }
+        }
         Ok(())
     }
 
@@ -930,6 +1083,162 @@ impl ProxyEngine {
         }
 
         Ok(())
+    }
+}
+
+// ── WebSocket frame sniffing (v0.3.35) ──────────────────────────────────────
+//
+// These parse RFC 6455 frames purely for logging. The proxy forwards the raw
+// bytes verbatim, so a parse failure can never corrupt the tunnel.
+
+/// A WebSocket frame with its payload already unmasked, captured for display.
+struct ParsedWsFrame {
+    opcode: u8,
+    payload: Vec<u8>,
+}
+
+fn ws_opcode_name(op: u8) -> &'static str {
+    match op {
+        0x0 => "continuation",
+        0x1 => "text",
+        0x2 => "binary",
+        0x8 => "close",
+        0x9 => "ping",
+        0xA => "pong",
+        _ => "unknown",
+    }
+}
+
+/// Turn a parsed frame into a `(display_string, byte_length)` pair for the UI.
+fn render_ws_frame(f: &ParsedWsFrame) -> (String, usize) {
+    let len = f.payload.len();
+    match f.opcode {
+        0x1 => {
+            let s = String::from_utf8_lossy(&f.payload);
+            (s.chars().take(4096).collect(), len)
+        }
+        0x8 => {
+            if f.payload.len() >= 2 {
+                let code = u16::from_be_bytes([f.payload[0], f.payload[1]]);
+                let reason = String::from_utf8_lossy(&f.payload[2..]);
+                (format!("close code={} reason={}", code, reason), len)
+            } else {
+                ("close".to_string(), len)
+            }
+        }
+        _ => {
+            let preview: String = f.payload.iter().take(32).map(|b| format!("{:02x}", b)).collect();
+            (format!("[{} bytes] {}", len, preview), len)
+        }
+    }
+}
+
+/// Parse as many complete WebSocket frames as possible from the front of `buf`.
+/// Returns the parsed frames (payloads unmasked) and the number of bytes
+/// consumed; an incomplete trailing frame is left for the next read.
+fn parse_ws_frames(buf: &[u8]) -> (Vec<ParsedWsFrame>, usize) {
+    let mut frames = Vec::new();
+    let mut pos = 0;
+    while buf.len() - pos >= 2 {
+        let rest = &buf[pos..];
+        let b0 = rest[0];
+        let b1 = rest[1];
+        let opcode = b0 & 0x0F;
+        let masked = (b1 & 0x80) != 0;
+        let len7 = (b1 & 0x7F) as usize;
+
+        let (mut header, payload_len) = if len7 == 126 {
+            if rest.len() < 4 {
+                break;
+            }
+            (4usize, u16::from_be_bytes([rest[2], rest[3]]) as usize)
+        } else if len7 == 127 {
+            if rest.len() < 10 {
+                break;
+            }
+            (
+                10usize,
+                u64::from_be_bytes([rest[2], rest[3], rest[4], rest[5], rest[6], rest[7], rest[8], rest[9]])
+                    as usize,
+            )
+        } else {
+            (2usize, len7)
+        };
+
+        let mask_offset = header;
+        if masked {
+            header += 4;
+        }
+        let total = header + payload_len;
+        if rest.len() < total {
+            break;
+        }
+
+        let mut payload = rest[header..total].to_vec();
+        if masked {
+            let key =
+                [rest[mask_offset], rest[mask_offset + 1], rest[mask_offset + 2], rest[mask_offset + 3]];
+            for (i, byte) in payload.iter_mut().enumerate() {
+                *byte ^= key[i % 4];
+            }
+        }
+
+        frames.push(ParsedWsFrame { opcode, payload });
+        pos += total;
+    }
+    (frames, pos)
+}
+
+#[cfg(test)]
+mod ws_frame_tests {
+    use super::*;
+
+    #[test]
+    fn parses_unmasked_text_frame() {
+        // FIN + text(0x1), len 2, "Hi"
+        let buf = [0x81u8, 0x02, b'H', b'i'];
+        let (frames, consumed) = parse_ws_frames(&buf);
+        assert_eq!(consumed, 4);
+        assert_eq!(frames.len(), 1);
+        assert_eq!(frames[0].opcode, 0x1);
+        assert_eq!(frames[0].payload, b"Hi");
+    }
+
+    #[test]
+    fn parses_masked_client_frame() {
+        // FIN + text, masked, len 2, key 01020304, "Hi" XOR key
+        let key = [0x01u8, 0x02, 0x03, 0x04];
+        let masked = [b'H' ^ key[0], b'i' ^ key[1]];
+        let buf = [0x81u8, 0x82, key[0], key[1], key[2], key[3], masked[0], masked[1]];
+        let (frames, consumed) = parse_ws_frames(&buf);
+        assert_eq!(consumed, 8);
+        assert_eq!(frames.len(), 1);
+        assert_eq!(frames[0].payload, b"Hi"); // unmasked back to plaintext
+    }
+
+    #[test]
+    fn leaves_incomplete_frame_unconsumed() {
+        // Header claims a masked 2-byte payload but only part is present.
+        let buf = [0x81u8, 0x82, 0x01, 0x02];
+        let (frames, consumed) = parse_ws_frames(&buf);
+        assert_eq!(consumed, 0);
+        assert!(frames.is_empty());
+    }
+
+    #[test]
+    fn parses_two_back_to_back_frames() {
+        let buf = [0x81u8, 0x01, b'A', 0x8A, 0x00]; // text "A" then a pong (0xA)
+        let (frames, consumed) = parse_ws_frames(&buf);
+        assert_eq!(consumed, 5);
+        assert_eq!(frames.len(), 2);
+        assert_eq!(ws_opcode_name(frames[1].opcode), "pong");
+    }
+
+    #[test]
+    fn renders_close_frame_code() {
+        let f = ParsedWsFrame { opcode: 0x8, payload: vec![0x03, 0xE8] }; // 1000
+        let (data, _) = render_ws_frame(&f);
+        assert!(data.contains("code=1000"));
     }
 }
 

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,6 +1,6 @@
 {  "$schema": "https://schema.tauri.app/config/2",
   "productName": "WonderSuite",
-  "version": "0.3.34",
+  "version": "0.3.35",
   "identifier": "com.wondersuite.app",
   "build": {
     "beforeDevCommand": "npm run dev",

--- a/src/modules/discovery/Discovery.tsx
+++ b/src/modules/discovery/Discovery.tsx
@@ -177,45 +177,41 @@ export function Discovery() {
     setSubRunning(false);
   }, [target, subRunning]);
 
+  // v0.3.35: param discovery now runs through the `discover_parameters` backend
+  // (MCP) tool — concurrent probing plus canary reflection detection, instead of
+  // the old sequential client-side size/status diff loop.
   const startParamDiscovery = useCallback(async () => {
     if (!target || paramRunning) return;
     if (!scopeGuard()) return;
     setParamRunning(true); setParamResults([]);
     try {
       const { invoke } = await import('@tauri-apps/api/core');
-      const params = [
-        'id', 'page', 'q', 'search', 'query', 'debug', 'test', 'admin', 'token',
-        'key', 'api_key', 'apikey', 'secret', 'password', 'pass', 'user', 'username',
-        'email', 'callback', 'redirect', 'redirect_uri', 'return', 'return_url', 'next',
-        'url', 'uri', 'path', 'file', 'filename', 'include', 'template', 'lang', 'language',
-        'action', 'type', 'format', 'output', 'v', 'version', 'limit', 'offset', 'sort',
-        'order', 'filter', 'category', 'tag', 'status', 'role', 'access', 'auth',
-        'view', 'mode', 'config', 'setting', 'option', 'cmd', 'command', 'exec',
-      ];
+      const result = await invoke('mcp_execute_tool', {
+        name: 'discover_parameters',
+        params: { target, method: paramMethod, wordlist: 'medium', max_concurrent: 10, timeout_ms: 5000 },
+      }) as {
+        baseline_status: number;
+        baseline_size: number;
+        parameters_tested: number;
+        parameters_found: number;
+        results: Array<{ param: string; evidence: string; status_code: number; response_size: number }>;
+      };
 
-      const baseline: { status: number; body: string; size: number } =
-        await invoke('send_http_request', { method: 'GET', url: target, headers: null, body: null });
-
-      const found: Array<{ param: string; evidence: string }> = [];
-      for (const param of params) {
-        try {
-          const testUrl = `${target}${target.includes('?') ? '&' : '?'}${param}=wondertest123`;
-          const r: { status: number; body: string; size: number } =
-            await invoke('send_http_request', { method: 'GET', url: testUrl, headers: null, body: null });
-
-          const sizeDiff = Math.abs(r.size - baseline.size);
-          if (sizeDiff > 50 || r.status !== baseline.status) {
-            found.push({
-              param,
-              evidence: `Status: ${r.status} (baseline: ${baseline.status}), Size diff: ${sizeDiff > 0 ? '+' : ''}${sizeDiff}B`,
-            });
-          }
-        } catch { /* ignore */ }
+      const formatted: Array<{ param: string; evidence: string }> = result.results.map(r => ({
+        param: r.param,
+        evidence: `${r.evidence} — ${r.status_code}/${r.response_size}B vs baseline ${result.baseline_status}/${result.baseline_size}B`,
+      }));
+      setParamResults(formatted);
+      if (formatted.length === 0) {
+        addToast({
+          title: 'Parameter discovery complete',
+          message: `Tested ${result.parameters_tested} parameters — none altered the response.`,
+          type: 'info',
+        });
       }
-      setParamResults(found);
     } catch (err) { notifyError('Param discovery failed', err); }
     setParamRunning(false);
-  }, [target, paramRunning]);
+  }, [target, paramMethod, paramRunning, scopeGuard, addToast]);
 
   const statusClass = (code: number) => {
     if (code < 300) return 's2xx'; if (code < 400) return 's3xx';

--- a/src/modules/docs/content/mcp-tools.md
+++ b/src/modules/docs/content/mcp-tools.md
@@ -12,7 +12,7 @@ WonderSuite exposes its full toolset over the [MCP server](page:settings-mcp) so
 
 ## Scanner
 
-`active_scan` — SQLi, XSS, SSTI, LFI, Open Redirect, CRLF, with optional `with_oast:true` for blind command injection, blind SSRF, and Log4Shell via the bundled OAST listener · `passive_scan` — headers, cookies, CORS, information disclosure
+`active_scan` — SQLi, XSS, SSTI, LFI, Open Redirect, CRLF, with optional `with_oast:true` for blind command injection, blind SSRF, and Log4Shell via the bundled OAST listener · `passive_scan` — headers, cookies, CORS, information disclosure · `graphql_scan` — introspect a GraphQL endpoint (flags introspection-enabled as a finding) and enumerate every query/mutation argument as injection points to feed into `active_scan` / `fuzz_request`
 
 ## Intruder
 
@@ -26,7 +26,7 @@ A pentest-grade browser surface driving WonderBrowser over a persistent CDP conn
 
 ## Recon
 
-`crawl_target` · `discover_content` · `discover_subdomains` · `find_secrets` · `dns_resolve` · `js_link_finder`
+`crawl_target` · `discover_content` · `discover_subdomains` · `discover_parameters` (hidden-parameter mining via canary reflection + status/size diff) · `find_secrets` · `dns_resolve` · `js_link_finder`
 
 ## OSINT
 

--- a/src/modules/docs/content/websocket.md
+++ b/src/modules/docs/content/websocket.md
@@ -25,6 +25,17 @@ Click any frame for the full untruncated payload in the detail pane. The log aut
 
 The box at the bottom sends a frame on the selected connection — type your message and click **Send** (or press <kbd>Enter</kbd>; <kbd>Shift+Enter</kbd> for a newline).
 
+## Intercepted tab
+
+Everything above operates on connections **you** open from WonderSuite. The
+**Intercepted** tab is different: it shows WebSocket frames the **MITM proxy**
+captured from real browser traffic. Start the proxy, browse a target that uses
+WebSockets, and every frame the proxy relays appears here live — direction
+(`C→S` / `S→C`), opcode (text / binary / ping / pong / close), size, and the
+host. Frames are forwarded byte-for-byte, so the relay never disturbs the
+connection; this view is for observation. (A connected AI agent reads the same
+stream via the `proxy_get_websocket_messages` MCP tool.)
+
 ## Match & Replace tab
 
 Rules here automatically rewrite WebSocket frames as they pass through. To add a rule:

--- a/src/modules/websocket/WebSocket.tsx
+++ b/src/modules/websocket/WebSocket.tsx
@@ -6,6 +6,8 @@ import './WebSocket.css';
 interface WsConnection { id: string; url: string; status: string; message_count: number; connected_at: string; }
 interface WsMessage { id: number; direction: string; data: string; msg_type: string; size: number; timestamp: string; }
 interface WsRule { id: string; name: string; enabled: boolean; direction: string; match_pattern: string; replace_value: string; is_regex: boolean; }
+// v0.3.35: frames captured by the MITM proxy (proxy_get_websocket_messages).
+interface ProxyWsFrame { id: number; connection_id: string; direction: string; opcode: string; data: string; length: number; timestamp: string; host: string; url: string; }
 
 interface ReplayFrame { id: string; data: string; delayMs: number; }
 interface ReplaySequence {
@@ -18,7 +20,7 @@ interface ReplaySequence {
 }
 interface ReplayLogEntry { ts: string; kind: 'info' | 'sent' | 'error'; text: string; }
 
-type WsTab = 'connections' | 'messages' | 'rules' | 'replay';
+type WsTab = 'connections' | 'messages' | 'rules' | 'replay' | 'intercepted';
 
 const REPLAY_STORAGE_KEY = 'ws_replay_sequences_v1';
 
@@ -46,6 +48,7 @@ export function WebSocket() {
   const [selectedConn, setSelectedConn] = useState<string | null>(null);
   const [messages, setMessages] = useState<WsMessage[]>([]);
   const [rules, setRules] = useState<WsRule[]>([]);
+  const [intercepted, setIntercepted] = useState<ProxyWsFrame[]>([]);
 
   const [connectUrl, setConnectUrl] = useState('wss://');
   const [sendMsg, setSendMsg] = useState('');
@@ -257,6 +260,15 @@ export function WebSocket() {
     } catch { setRules([]); }
   }, []);
 
+  // v0.3.35: poll the MITM proxy's WebSocket pool for intercepted frames.
+  const loadIntercepted = useCallback(async () => {
+    try {
+      const { invoke } = await import('@tauri-apps/api/core');
+      const data: ProxyWsFrame[] = await invoke('proxy_get_websocket_messages');
+      setIntercepted(data);
+    } catch { setIntercepted([]); }
+  }, []);
+
   useEffect(() => {
     loadConnections();
     loadRules();
@@ -278,6 +290,14 @@ export function WebSocket() {
   useEffect(() => {
     msgEndRef.current?.scrollIntoView({ behavior: 'smooth' });
   }, [messages]);
+
+  // Live-poll intercepted proxy frames only while that tab is open.
+  useEffect(() => {
+    if (tab !== 'intercepted') return;
+    loadIntercepted();
+    const t = setInterval(loadIntercepted, 1500);
+    return () => clearInterval(t);
+  }, [tab, loadIntercepted]);
 
   const connect = async () => {
     if (!connectUrl || connectUrl === 'wss://') return;
@@ -356,6 +376,9 @@ export function WebSocket() {
         </button>
         <button className={`ws-tab ${tab === 'replay' ? 'active' : ''}`} onClick={() => setTab('replay')}>
           <Play size={10} /> Replay <span className="ws-badge">{sequences.length}</span>
+        </button>
+        <button className={`ws-tab ${tab === 'intercepted' ? 'active' : ''}`} onClick={() => setTab('intercepted')}>
+          <Wifi size={10} /> Intercepted {intercepted.length > 0 && <span className="ws-badge">{intercepted.length}</span>}
         </button>
       </div>
 
@@ -709,6 +732,45 @@ export function WebSocket() {
                     onClick={createSequence}>
                     <Plus size={10} /> New Sequence
                   </button>
+                </div>
+              )}
+            </div>
+          </div>
+        )}
+
+        {/* Intercepted (MITM proxy) Tab — v0.3.35 */}
+        {tab === 'intercepted' && (
+          <div className="ws-messages-panel">
+            <div className="ws-messages-header">
+              <Wifi size={12} />
+              <span className="ws-conn-active-url">Proxy-intercepted WebSocket frames</span>
+              <span className="ws-dim">{intercepted.length} frames · live from the MITM proxy</span>
+            </div>
+            <div className="ws-messages-list">
+              {[...intercepted].reverse().map(f => {
+                const dir = f.direction === 'client_to_server' ? 'sent' : 'received';
+                return (
+                  <div key={f.id} className={`ws-msg ${dir}`}>
+                    <div className="ws-msg-indicator">
+                      {dir === 'sent' ? <ArrowUp size={10} /> : <ArrowDown size={10} />}
+                    </div>
+                    <div className="ws-msg-content">
+                      <div className="ws-msg-header">
+                        <span className={`ws-msg-dir ${dir}`}>{dir === 'sent' ? 'C→S' : 'S→C'}</span>
+                        <span className="ws-msg-type">{f.opcode}</span>
+                        <span className="ws-dim">{f.length}B</span>
+                        <span className="ws-dim">{f.host}</span>
+                      </div>
+                      <pre className="ws-msg-data">{f.data.slice(0, 200)}{f.data.length > 200 ? '…' : ''}</pre>
+                    </div>
+                  </div>
+                );
+              })}
+              {intercepted.length === 0 && (
+                <div className="ws-empty" style={{ padding: 20 }}>
+                  <Wifi size={24} strokeWidth={1} />
+                  <span>No intercepted WebSocket frames yet</span>
+                  <span className="ws-dim">Start the proxy and browse a site that uses WebSockets — frames captured by the MITM proxy appear here live.</span>
                 </div>
               )}
             </div>


### PR DESCRIPTION
## WonderSuite 0.3.35

Closes four feature gaps against Burp Suite, each reachable **both** from the UI and as an **MCP tool**.

### WebSocket frame interception
The MITM proxy now relays WS frames byte-for-byte and captures each one — previously it only logged the upgrade and dropped every subsequent frame. New **Intercepted** tab in the WebSocket module; the agent reads the same stream via `proxy_get_websocket_messages`. (`proxy/engine.rs`, `WebSocket.tsx`)

### `graphql_scan`
Introspection with 7-level type resolution → an "introspection enabled" finding plus an enumerated injection surface (every query/mutation scalar argument) ready for `active_scan` / `intruder`. (`mcp/handlers/scanner/graphql.rs`)

### `discover_parameters`
Concurrent hidden-parameter mining via canary reflection + status/size diff against a baseline. Wires the Discovery "Hidden Parameters" tab to a real backend. (`mcp/handlers/recon.rs`, `Discovery.tsx`)

### Adaptive throttling
Intruder now backs off automatically on `429`/`503` (exponential, honoring `Retry-After`). Additive model that stays correct at the default `throttle_ms = 0`. (`backoff.rs`, `intruder.rs`)

### Verification
- 24 new unit tests (backoff, WS-frame parsing, GraphQL schema/injection points, param-evidence, intruder config back-compat).
- Local CI mirror green: `cargo fmt --check`, `cargo check --locked --all-targets`, `cargo clippy --locked --all-targets`, `tsc --noEmit`, `vite build`.
- No new dependencies — Cargo.lock unchanged except the version bump.

Version bumped 0.3.34 → 0.3.35 (package.json, tauri.conf.json, Cargo.toml); CHANGELOG + in-app docs updated.
